### PR TITLE
Generalized approxPastEnergy.m and approxFutureEnergy.m to handle polynomial (QB) input vector fields

### DIFF
--- a/approxFutureEnergy.m
+++ b/approxFutureEnergy.m
@@ -111,13 +111,13 @@ w{2} = vec(W2);
 if (d > 2)
   GaWb = cell(2 * l + 1, d - 1); % Pre-compute G_a.'*W_b, etc for all the a,b we need
   GaWb{1, 2} = B.' * W2;
-  Im = speye(m);
   % set up the generalized Lyapunov solver
   [Acell{1:d}] = deal(A.' - eta * W2 * (B * B.'));
 
   b = -LyapProduct(N.', w{2}, 2);
 
   if l > 0 % New for QB/polynomial input
+    Im = speye(m);
     GaWb{2, 2} = g{2}.' * W2;
     b = b + 2 * eta * kron(speye(n ^ 3), vec(Im).') * vec(kron(GaWb{2, 2}, GaWb{1, 2}));
   end

--- a/approxFutureEnergy.m
+++ b/approxFutureEnergy.m
@@ -109,8 +109,8 @@ w{2} = vec(W2);
 
 %% k=3 case
 if (d > 2)
-  NaWb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*W_b, etc for all the a,b we need
-  NaWb{1, 2} = B.' * W2;
+  GaWb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*W_b, etc for all the a,b we need
+  GaWb{1, 2} = B.' * W2;
   Im = speye(m);
   % set up the generalized Lyapunov solver
   [Acell{1:d}] = deal(A.' - eta * W2 * (B * B.'));
@@ -118,8 +118,8 @@ if (d > 2)
   b = -LyapProduct(N.', w{2}, 2);
 
   if l > 0 % New for QB/polynomial input
-    NaWb{2, 2} = g{2}.' * W2;
-    b = b + 2 * eta * kron(speye(n ^ 3), vec(Im).') * vec(kron(NaWb{2, 2}, NaWb{1, 2}));
+    GaWb{2, 2} = g{2}.' * W2;
+    b = b + 2 * eta * kron(speye(n ^ 3), vec(Im).') * vec(kron(GaWb{2, 2}, GaWb{1, 2}));
   end
 
   [w{3}] = KroneckerSumSolver(Acell(1:3), b, 3); % Solve Ax=b for k=3
@@ -127,21 +127,21 @@ if (d > 2)
 
   %% k>3 cases (up to d)
   for k = 4:d
-    NaWb{1, k - 1} = B.' * reshape(w{k - 1}, n, n ^ (k - 2));
+    GaWb{1, k - 1} = B.' * reshape(w{k - 1}, n, n ^ (k - 2));
 
     b = -LyapProduct(N.', w{k - 1}, k - 1); % Pre-compue all the L(N') terms
 
     % Now add all the terms from the 'B' sum by looping through the i and j
     for i = 3:(k + 1) / 2 % i+j=k+2
       j = k + 2 - i;
-      tmp = NaWb{1, i}.' * NaWb{1, j};
+      tmp = GaWb{1, i}.' * GaWb{1, j};
       b = b + 0.25 * eta * i * j * (vec(tmp) + vec(tmp.'));
     end
 
     if ~mod(k, 2) % k is even
       i = (k + 2) / 2;
       j = i;
-      tmp = NaWb{1, i}.' * NaWb{1, j};
+      tmp = GaWb{1, i}.' * GaWb{1, j};
       b = b + 0.25 * eta * i * j * vec(tmp);
     end
 
@@ -149,7 +149,7 @@ if (d > 2)
     [g{l + 2:2 * l + 1}] = deal(0); % Need an extra space in g because of NaVb indexing
 
     for o = 1:2 * l
-      NaWb{o + 1, k - 1} = g{o + 1}.' * reshape(w{k - 1}, n, n ^ (k - 2));
+      GaWb{o + 1, k - 1} = g{o + 1}.' * reshape(w{k - 1}, n, n ^ (k - 2));
 
       for p = max(0, o - l):min(o, l)
 
@@ -157,7 +157,7 @@ if (d > 2)
           q = o - p;
           j = k - o - i + 2;
           tmp = kron(speye(n ^ p), vec(Im).') ...
-            * kron(vec(NaWb{q + 1, j}).', kron(NaWb{p + 1, i}, Im)) ...
+            * kron(vec(GaWb{q + 1, j}).', kron(GaWb{p + 1, i}, Im)) ...
             * kron(speye(n ^ (j - 1)), kron(perfectShuffle(n ^ (i - 1), n ^ q * m), Im)) ...
             * kron(speye(n ^ (k - p)), vec(Im));
           b = b + 0.25 * eta * i * j * vec(tmp);

--- a/approxFutureEnergy.m
+++ b/approxFutureEnergy.m
@@ -52,15 +52,15 @@ if (nargin < 7)
 end
 
 % Create pointer/shortcuts for dynamical system polynomial coefficients
-if ismatrix(g)
+if iscell(g)
+  % QB or polynomial input balancing
+  B = g{1};
+  l = length(g) - 1;
+else
   % Will reduce to Jeff's original code
   B = g;
   l = 0;
   g = {B};
-else
-  % QB or polynomial input balancing
-  B = g{1};
-  l = length(g) - 1;
 end
 
 n = size(A, 1); % A should be n-by-n

--- a/approxFutureEnergy.m
+++ b/approxFutureEnergy.m
@@ -109,7 +109,7 @@ w{2} = vec(W2);
 
 %% k=3 case
 if (d > 2)
-  GaWb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*W_b, etc for all the a,b we need
+  GaWb = cell(2 * l + 1, d - 1); % Pre-compute G_a.'*W_b, etc for all the a,b we need
   GaWb{1, 2} = B.' * W2;
   Im = speye(m);
   % set up the generalized Lyapunov solver

--- a/approxFutureEnergy.m
+++ b/approxFutureEnergy.m
@@ -1,131 +1,176 @@
-function [w] = approxFutureEnergy(A,N,B,C,eta,d,verbose)
+function [w] = approxFutureEnergy(A, N, g, C, eta, d, verbose)
 %  Calculates a polynomial approximation to the future energy function
-%  for a quadratic system.
+%  for a quadratic drift, polynomial input system. The default usage is
 %
-%  w = approxFutureEnergy(A,N,B,C,eta,d) 
+%  w = approxFutureEnergy(A,N,g,C,eta,d,verbose)
 %
-%  Computes a degree d polynomial approximation to the future energy function 
+%  where 'verbose' is an optional argument. If the system has a constant
+%  input vector field Bu, the matrix B may be passes in place of a cell
+%  array 'g'.The cell array 'g' should be g{1} = B = G_0, g{2} = G1, g{3} = G2 ...
+%
+%  Computes a degree d polynomial approximation to the future energy function
 %
 %          E^+(x) = 1/2 ( w{2}'*kron(x,x) + ... + w{d}'*kron(.. x) )
 %
 %  for the polynomial system
 %
-%    \dot{x} = Ax + Bu + N*kron(x,x)
+%    \dot{x} = Ax + Bu + N*kron(x,x) + G1*kron(x,u) + G2*kron(x,x,u) + ...
 %          y = Cx
 %
 %  where eta = 1-gamma^(-2), gamma is the parameter in the algebraic Riccati
-%  equation for W2,
+%  equation
 %
-%    A'*W2 + W2*A - eta*W2*B*B'*W2 + C'*C = 0.
+%    A'*W2 + W2*A - eta*W2*B*B'*W2 + C'*C = 0,
 %
-%  Note that w2 = vec(W2).  Details are in Section III.B of the reference.
+%  and in the subsequent linear systems arising from the Future H-infinity
+%  Hamilton-Jacobi-Bellman Partial Differential Equation.
+%
+%  Note that w{2} = vec(W2) = W2(:).  Details are in Section III.B of reference [1].
 %
 %  Requires the following functions from the KroneckerTools repository:
 %      KroneckerSumSolver
 %      kronMonomialSymmetrize
 %      LyapProduct
 %
-%  Author: Jeff Borggaard, Virginia Tech
+%  Authors: Jeff Borggaard, Virginia Tech
+%           Nick Corbin, UCSD
 %
 %  License: MIT
 %
-%  Reference: Nonlinear balanced truncation: Part 1--Computing energy functions,
-%             by Kramer, Gugercin, and Borggaard, arXiv:2209.07645.
+%  Reference: [1] Nonlinear balanced truncation: Part 1--Computing energy
+%             functions, by Kramer, Gugercin, and Borggaard, arXiv:2209.07645.
+%             [2] Nonlinear balanced truncation for quadratic bilinear
+%             systems, by Nick Corbin ... (in progress).
 %
-%             See Algorithm 1.
+%             See Algorithm 1 in [1].
 %
 %  Part of the NLbalancing repository.
 %%
 
-  if (nargin<7)
-    verbose = false;
+if (nargin < 7)
+  verbose = false;
+end
+
+% Create pointer/shortcuts for dynamical system polynomial coefficients
+if ismatrix(g)
+  % Will reduce to Jeff's original code
+  B = g;
+  l = 0;
+  g = {B};
+else
+  % QB or polynomial input balancing
+  B = g{1};
+  l = length(g) - 1;
+end
+
+n = size(A, 1); % A should be n-by-n
+m = size(B, 2); % B should be n-by-m
+p = size(C, 1); % C should be p-by-n
+
+% Create a vec function for readability
+vec = @(X) X(:);
+
+%% k=2 case
+R = eye(m) / eta;
+
+if (eta > 0)
+  [W2] = icare(A, B, (C.' * C), R);
+
+  if (isempty(W2) && verbose)
+    warning('approxFutureEnergy: icare couldn''t find stabilizing solution')
   end
 
-  n = size(A,1);   % A should be n-by-n
-  m = size(B,2);   % B should be n-by-m
-  p = size(C,1);   % C should be p-by-n
+elseif (eta < 0)
+  [W2] = icare(A, B, (C.' * C), R, 'anti');
 
-  % Create a vec function for readability
-  vec = @(X) X(:);
-
-
-  %% k=2 case
-  R = eye(m)/eta;
-
-  if ( eta>0 )
-    [W2] = icare(A,B,(C.'*C),R);
-    if ( isempty(W2) && verbose )
-      warning('approxFutureEnergy: icare couldn''t find stabilizing solution')
-    end
-    
-  elseif ( eta<0 )
-    [W2] = icare(A,B,(C.'*C),R,'anti');
-    
-    if ( isempty(W2) && verbose )
-      warning('approxFutureEnergy: icare couldn''t find stabilizing solution')
-      warning('approxFutureEnergy: using the hamiltonian')
-      [~,W2,~] = hamiltonian(A,B,C.'*C,R,true);
-    end
-    
-  else % eta==0
-    [W2] = lyap(A.',(C.'*C));
-    
+  if (isempty(W2) && verbose)
+    warning('approxFutureEnergy: icare couldn''t find stabilizing solution')
+    warning('approxFutureEnergy: using the hamiltonian')
+    [~, W2, ~] = hamiltonian(A, B, C.' * C, R, true);
   end
 
-  if (isempty(W2))
-    error('approxFutureEnergy: Can''t find a stabilizing solution')
-  end
-  
-  %  Check the residual of the Riccati/Lyapunov equation
-  if (verbose)
-    RES = A'*W2 + W2*A - eta*(W2*B)*(B'*W2) + C'*C ;
-    fprintf('The residual of the Riccati equation is %g\n',norm(RES,'inf'));
+else % eta==0
+  [W2] = lyap(A.', (C.' * C));
+
+end
+
+if (isempty(W2))
+  error('approxFutureEnergy: Can''t find a stabilizing solution')
+end
+
+%  Check the residual of the Riccati/Lyapunov equation
+if (verbose)
+  RES = A' * W2 + W2 * A - eta * (W2 * B) * (B' * W2) + C' * C;
+  fprintf('The residual of the Riccati equation is %g\n', norm(RES, 'inf'));
+end
+
+%  Reshape the resulting quadratic coefficients
+w{2} = vec(W2);
+
+%% k=3 case
+if (d > 2)
+  NaWb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*W_b, etc for all the a,b we need
+  NaWb{1, 2} = B.' * W2;
+  Im = speye(m);
+  % set up the generalized Lyapunov solver
+  [Acell{1:d}] = deal(A.' - eta * W2 * (B * B.'));
+
+  b = -LyapProduct(N.', w{2}, 2);
+
+  if l > 0 % New for QB/polynomial input
+    NaWb{2, 2} = g{2}.' * W2;
+    b = b + 2 * eta * kron(speye(n ^ 3), vec(Im).') * vec(kron(NaWb{2, 2}, NaWb{1, 2}));
   end
 
-  %  Reshape the resulting quadratic coefficients
-  w2 = W2(:);
-  w{2} = w2;
+  [w{3}] = KroneckerSumSolver(Acell(1:3), b, 3); % Solve Ax=b for k=3
+  [w{3}] = kronMonomialSymmetrize(w{3}, n, 3); % Symmetrize w3
 
-  %% k=3 case
-  if ( d>2 ) % set up the generalized Lyapunov solver
-    W2BB = W2*(B*B.');
-    Acell = cell(1,d);
-    for i=1:d
-      Acell{i} = A.'-eta*W2BB;
-    end
-
-    b = -LyapProduct(N.',w2,2);
-    [w{3}] = KroneckerSumSolver(Acell(1:3),b,3);
-    
-    [w{3}] = kronMonomialSymmetrize(w{3},n,3);
-  end
-  
   %% k>3 cases (up to d)
-  BWk = cell(1,d-1);
-  if ( d>3 )
+  for k = 4:d
+    NaWb{1, k - 1} = B.' * reshape(w{k - 1}, n, n ^ (k - 2));
 
-    for k=4:d
-      BWk{k-1} = B.'*reshape(w{k-1},n,n^(k-2));
+    b = -LyapProduct(N.', w{k - 1}, k - 1); % Pre-compue all the L(N') terms
 
-      b = -LyapProduct(N.',w{k-1},k-1);
-      
-      for i=3:(k+1)/2
-        j   = k+2-i;
-        tmp = BWk{i}.'*BWk{j};
-        b   = b + 0.25*eta*i*j*(vec(tmp) + vec(tmp.'));
-      end
-
-      if (mod(k,2)==0) % k is even
-        i   = (k+2)/2; 
-        j   = i;
-        tmp = BWk{i}.'*BWk{j};
-        b   = b + 0.25*eta*i*j*vec(tmp);
-      end
-
-      [w{k}] = KroneckerSumSolver(Acell(1:k),b,k);
-
-      [w{k}] = kronMonomialSymmetrize(w{k},n,k);
+    % Now add all the terms from the 'B' sum by looping through the i and j
+    for i = 3:(k + 1) / 2 % i+j=k+2
+      j = k + 2 - i;
+      tmp = NaWb{1, i}.' * NaWb{1, j};
+      b = b + 0.25 * eta * i * j * (vec(tmp) + vec(tmp.'));
     end
+
+    if ~mod(k, 2) % k is even
+      i = (k + 2) / 2;
+      j = i;
+      tmp = NaWb{1, i}.' * NaWb{1, j};
+      b = b + 0.25 * eta * i * j * vec(tmp);
+    end
+
+    % Now add the higher order polynomial terms by iterating through the sums
+    [g{l + 2:2 * l + 1}] = deal(0); % Need an extra space in g because of NaVb indexing
+
+    for o = 1:2 * l
+      NaWb{o + 1, k - 1} = g{o + 1}.' * reshape(w{k - 1}, n, n ^ (k - 2));
+
+      for p = max(0, o - l):min(o, l)
+
+        for i = 2:k - o
+          q = o - p;
+          j = k - o - i + 2;
+          tmp = kron(speye(n ^ p), vec(Im).') ...
+            * kron(vec(NaWb{q + 1, j}).', kron(NaWb{p + 1, i}, Im)) ...
+            * kron(speye(n ^ (j - 1)), kron(perfectShuffle(n ^ (i - 1), n ^ q * m), Im)) ...
+            * kron(speye(n ^ (k - p)), vec(Im));
+          b = b + 0.25 * eta * i * j * vec(tmp);
+        end
+
+      end
+
+    end
+
+    [w{k}] = KroneckerSumSolver(Acell(1:k), b, k);
+    [w{k}] = kronMonomialSymmetrize(w{k}, n, k);
   end
+
+end
 
 end

--- a/approxPastEnergy.m
+++ b/approxPastEnergy.m
@@ -1,157 +1,200 @@
-function [v] = approxPastEnergy(A,N,B,C,eta,d,verbose)
-%  Calculates a polynomial approximation to the past energy function
-%  for a quadratic system.
-%
-%  v = approxPastEnergy(A,N,B,C,eta,d) 
-%
-%  Computes a degree d polynomial approximation to the past energy function 
-%
-%          E^-(x) = 1/2 ( v{2}'*kron(x,x) + ... + v{d}'*kron(.. x) )
-%
-%  for the polynomial system
-%
-%    \dot{x} = Ax + N*kron(x,x) + Bu
-%          y = Cx
-%
-%  where eta = 1-gamma^(-2), gamma is the parameter in the algebraic Riccati
-%  equation
-%
-%    A'*V2 + V2*A + V2*B*B'*V2 - eta*C'*C = 0.
-%
-%  Note that v{2} = vec(V2) = V2(:).  Details are in Section III.C of the paper.
-%
-%  Requires functions from the KroneckerTools repository
-%      KroneckerSumSolver
-%      kronMonomialSymmetrize
-%      LyapProduct
-%
-%  Author: Jeff Borggaard, Virginia Tech
-%
-%  License: MIT
-%
-%  Reference: Nonlinear balanced truncation: Part 1--Computing energy functions,
-%             by Kramer, Gugercin, and Borggaard, arXiv:2209.07645.
-%
-%             See Algorithm 1.
-%
-%  Part of the NLbalancing repository.
-%%
+function [v] = approxPastEnergy(A, N, g, C, eta, d, verbose)
+  %  Calculates a polynomial approximation to the past energy function
+  %  for a quadratic drift, polynomial input system. The default usage is
+  %
+  %  v = approxPastEnergy(A,N,g,C,eta,d,verbose)
+  %
+  %  where 'verbose' is an optional argument. If the system has a constant
+  %  input vector field Bu, the matrix B may be passes in place of the cell
+  %  array 'g'. The cell array 'g' should be g{1} = B = G_0, g{2} = G1, g{3} = G2 ...
+  %
+  %  Computes a degree d polynomial approximation to the past energy function
+  %
+  %          E^-(x) = 1/2 ( v{2}'*kron(x,x) + ... + v{d}'*kron(.. x) )
+  %
+  %  for the polynomial system
+  %
+  %    \dot{x} = Ax + Bu + N*kron(x,x) + G1*kron(x,u) + G2*kron(x,x,u) + ...
+  %          y = Cx
+  %
+  %  where eta = 1-gamma^(-2), gamma is the parameter in the algebraic Riccati
+  %  equation
+  %
+  %    A'*V2 + V2*A + V2*B*B'*V2 - eta*C'*C = 0.
+  %
+  %  and in the subsequent linear systems arising from the Past H-infinity
+  %  Hamilton-Jacobi-Bellman Partial Differential Equation.
+  %
+  %  Note that v{2} = vec(V2) = V2(:).  Details are in Section III.C of reference [1].
+  %
+  %  Requires the following functions from the KroneckerTools repository
+  %      KroneckerSumSolver
+  %      kronMonomialSymmetrize
+  %      LyapProduct
+  %
+  %  Authors: Jeff Borggaard, Virginia Tech
+  %           Nick Corbin, UCSD
+  %
+  %  License: MIT
+  %
+  %  Reference: [1] Nonlinear balanced truncation: Part 1--Computing energy
+  %             functions, by Kramer, Gugercin, and Borggaard, arXiv:2209.07645.
+  %             [2] Nonlinear balanced truncation for quadratic bilinear
+  %             systems, by Nick Corbin ... (in progress).
+  %
+  %             See Algorithm 1 in [1].
+  %
+  %  Part of the NLbalancing repository.
+  %%
 
-  if (nargin<7)
-    verbose = false;
+  if (nargin < 7)
+      verbose = false;
   end
 
-  n = size(A,1);   % A should be n-by-n
-  m = size(B,2);   % B should be n-by-m
-  p = size(C,1);   % C should be p-by-n
-
-  Acell = cell(1,d);
-  for i=1:d
-    Acell{i} = A.';
+  % Create pointer/shortcuts for dynamical system polynomial coefficients
+  if ismatrix(g)
+      % Will reduce to Jeff's original code
+      B = g;
+      l = 0;
+      g = {B};
+  else
+      % QB or polynomial input balancing
+      B = g{1};
+      l = length(g) - 1;
   end
+
+  n = size(A, 1); % A should be n-by-n
+  m = size(B, 2); % B should be n-by-m
+  p = size(C, 1); % C should be p-by-n
 
   % Create a vec function for readability
   vec = @(X) X(:);
 
-
   %% k=2 case
   R = eye(m);
-  
-  if ( eta~=0 )
-    %  We multiply the ARE by -1 to put it into the standard form in icare,
-    %  and know (-A,-B) is a controllable pair if (A,B) is.
-    [V2] = icare(-A,-B,eta*(C.'*C),R);
 
-    if ( isempty(V2) && verbose )
-      warning('approxPastEnergy: icare couldn''t find stabilizing solution')
-    end
-    
-    if ( isempty(V2) )
-      if (verbose) 
-        warning('approxPastEnergy: using matrix inverse')
-      end
-      [Yinf] = icare(A.',C.',B*B.',eye(p)/eta);
-      if ( isempty(Yinf) )
-        V2 = [];
-      else
-        V2 = inv(Yinf);  % yikes!!!
-      end
-    end
+  if (eta ~= 0)
+      %  We multiply the ARE by -1 to put it into the standard form in icare,
+      %  and know (-A,-B) is a controllable pair if (A,B) is.
+      [V2] = icare(-A, -B, eta * (C.' * C), R);
 
-    if ( isempty(V2) )
-      if (verbose), fprintf("trying the anti-solution\n"), end
-      [V2] = icare(-A,B,eta*(C.'*C),R,'anti');
-    end
-    
-    if ( isempty(V2) )
-      if (verbose)
-        warning('approxPastEnergy: icare couldn''t find stabilizing solution')
-        fprintf('approxPastEnergy: using the hamiltonian\n')
+      if (isempty(V2) && verbose)
+          warning('approxPastEnergy: icare couldn''t find stabilizing solution')
       end
-      [~,V2,~] = hamiltonian(-A,B,eta*(C.'*C),R,true);
-      V2 = real(V2);
-    end
-     
-    if ( isempty(V2) )
-      error('Could not find a solution to the ARE, adjust the eta parameter')
-    end
-  
+
+      if (isempty(V2))
+
+          if (verbose)
+              warning('approxPastEnergy: using matrix inverse')
+          end
+
+          [Yinf] = icare(A.', C.', B * B.', eye(p) / eta);
+
+          if (isempty(Yinf))
+              V2 = [];
+          else
+              V2 = inv(Yinf); % yikes!!!
+          end
+
+      end
+
+      if (isempty(V2))
+          if (verbose), fprintf("trying the anti-solution\n"), end
+          [V2] = icare(-A, B, eta * (C.' * C), R, 'anti');
+      end
+
+      if (isempty(V2))
+
+          if (verbose)
+              warning('approxPastEnergy: icare couldn''t find stabilizing solution')
+              fprintf('approxPastEnergy: using the hamiltonian\n')
+          end
+
+          [~, V2, ~] = hamiltonian(-A, B, eta * (C.' * C), R, true);
+          V2 = real(V2);
+      end
+
+      if (isempty(V2))
+          error('Could not find a solution to the ARE, adjust the eta parameter')
+      end
+
   else % eta==0
-    %  This case is described in Section II.B of the paper and requires a
-    %  matrix inverse to calculate E_c.
-    [V2] = lyap(A,(B*B.'));
-    V2 = inv(V2); % yikes!!!!!!!!
+      %  This case is described in Section II.B of the paper and requires a
+      %  matrix inverse to calculate E_c.
+      [V2] = lyap(A, (B * B.'));
+      V2 = inv(V2); % yikes!!!!!!!!
 
-    %  To do: look at approximating this by [V2] = icare(-A,-B,eta*(C.'*C),R)
-    %  with a small value of eta (and perhaps other choices for C.'*C)
-    
+      %  To do: look at approximating this by [V2] = icare(-A,-B,eta*(C.'*C),R)
+      %  with a small value of eta (and perhaps other choices for C.'*C)
+
   end
-  
+
   %  Reshape the resulting quadratic coefficients
-  v2 = V2(:);
-  v{2} = v2;
+  v{2} = vec(V2);
 
   %% k=3 case
-  if ( d>2 )
-    % set up the generalized Lyapunov solver
-    V2BB = V2*(B*B.');
-    Acell = cell(1,d);
-    for i=1:d
-      Acell{i} = A.'+V2BB;
-    end
-  
-    b = -LyapProduct(N.',v2,2);
-    [v{3}] = KroneckerSumSolver(Acell(1:3),b,3);
+  if (d > 2)
+      NaVb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*V_b, etc for all the a,b we need
+      NaVb{1, 2} = B.' * V2; % Recall g{1} = B
+      % set up the generalized Lyapunov solver
+      [Acell{1:d}] = deal(A.' + V2 * (B * B.'));
 
-    [v{3}] = kronMonomialSymmetrize(v{3},n,3);
-  end
-  
-  %% k>3 case (up to d)
-  BVk = cell(1,d-1);
-  if ( d>3 )
+      b = -LyapProduct(N.', v{2}, 2);
 
-    for k=4:d
-      BVk{k-1} = B.'*reshape(v{k-1},n,n^(k-2));
-
-      b = -LyapProduct(N.',v{k-1},k-1);
-
-      for i=3:(k+1)/2
-        j   = k+2-i;
-        tmp = BVk{i}.'*BVk{j};
-        b   = b - 0.25*i*j*(vec(tmp) + vec(tmp.'));
+      if l > 0 % New for QB/polynomial input
+          Im = speye(m);
+          NaVb{2, 2} = g{2}.' * V2;
+          b = b - 2 * kron(speye(n ^ 3), vec(Im).') * vec(kron(NaVb{2, 2}, NaVb{1, 2}));
       end
 
-      if (mod(k,2)==0) % k is even
-        i   = (k+2)/2;
-        j   = i;
-        tmp = BVk{i}.'*BVk{j};
-        b   = b - 0.25*i*j*vec(tmp);
+      [v{3}] = KroneckerSumSolver(Acell(1:3), b, 3);
+      [v{3}] = kronMonomialSymmetrize(v{3}, n, 3);
+
+      %% k>3 case (up to d)
+      for k = 4:d
+          NaVb{1, k - 1} = B.' * reshape(v{k - 1}, n, n ^ (k - 2));
+
+          b = -LyapProduct(N.', v{k - 1}, k - 1);
+
+          for i = 3:(k + 1) / 2
+              j = k + 2 - i;
+              tmp = NaVb{1, i}.' * NaVb{1, j};
+              b = b - 0.25 * i * j * (vec(tmp) + vec(tmp.'));
+          end
+
+          if ~mod(k, 2) % k is even
+              i = (k + 2) / 2;
+              j = i;
+              tmp = NaVb{1, i}.' * NaVb{1, j};
+              b = b - 0.25 * i * j * vec(tmp);
+          end
+
+          % Now add the higher order polynomial terms by iterating through the sums
+          [g{l + 2:2 * l + 1}] = deal(0); % Need an extra space in g because of NaVb indexing
+
+          for o = 1:2 * l
+              NaVb{o + 1, k - 1} = g{o + 1}.' * reshape(v{k - 1}, n, n ^ (k - 2));
+
+              for p = max(0, o - l):min(o, l)
+
+                  for i = 2:k - o
+                      q = o - p;
+                      j = k - o - i + 2;
+                      tmp = kron(speye(n ^ p), vec(Im).') ...
+                          * kron(vec(NaVb{q + 1, j}).', kron(NaVb{p + 1, i}, Im)) ...
+                          * kron(speye(n ^ (j - 1)), kron(perfectShuffle(n ^ (i - 1), n ^ q * m), Im)) ...
+                          * kron(speye(n ^ (k - p)), vec(Im));
+                      b = b - 0.25 * i * j * vec(tmp);
+                  end
+
+              end
+
+          end
+
+          [v{k}] = KroneckerSumSolver(Acell(1:k), b, k);
+          [v{k}] = kronMonomialSymmetrize(v{k}, n, k);
       end
 
-      [v{k}] = KroneckerSumSolver(Acell(1:k),b,k);
-
-      [v{k}] = kronMonomialSymmetrize(v{k},n,k);
-    end
   end
-  
+
 end

--- a/approxPastEnergy.m
+++ b/approxPastEnergy.m
@@ -1,200 +1,200 @@
 function [v] = approxPastEnergy(A, N, g, C, eta, d, verbose)
-  %  Calculates a polynomial approximation to the past energy function
-  %  for a quadratic drift, polynomial input system. The default usage is
-  %
-  %  v = approxPastEnergy(A,N,g,C,eta,d,verbose)
-  %
-  %  where 'verbose' is an optional argument. If the system has a constant
-  %  input vector field Bu, the matrix B may be passes in place of the cell
-  %  array 'g'. The cell array 'g' should be g{1} = B = G_0, g{2} = G1, g{3} = G2 ...
-  %
-  %  Computes a degree d polynomial approximation to the past energy function
-  %
-  %          E^-(x) = 1/2 ( v{2}'*kron(x,x) + ... + v{d}'*kron(.. x) )
-  %
-  %  for the polynomial system
-  %
-  %    \dot{x} = Ax + Bu + N*kron(x,x) + G1*kron(x,u) + G2*kron(x,x,u) + ...
-  %          y = Cx
-  %
-  %  where eta = 1-gamma^(-2), gamma is the parameter in the algebraic Riccati
-  %  equation
-  %
-  %    A'*V2 + V2*A + V2*B*B'*V2 - eta*C'*C = 0.
-  %
-  %  and in the subsequent linear systems arising from the Past H-infinity
-  %  Hamilton-Jacobi-Bellman Partial Differential Equation.
-  %
-  %  Note that v{2} = vec(V2) = V2(:).  Details are in Section III.C of reference [1].
-  %
-  %  Requires the following functions from the KroneckerTools repository
-  %      KroneckerSumSolver
-  %      kronMonomialSymmetrize
-  %      LyapProduct
-  %
-  %  Authors: Jeff Borggaard, Virginia Tech
-  %           Nick Corbin, UCSD
-  %
-  %  License: MIT
-  %
-  %  Reference: [1] Nonlinear balanced truncation: Part 1--Computing energy
-  %             functions, by Kramer, Gugercin, and Borggaard, arXiv:2209.07645.
-  %             [2] Nonlinear balanced truncation for quadratic bilinear
-  %             systems, by Nick Corbin ... (in progress).
-  %
-  %             See Algorithm 1 in [1].
-  %
-  %  Part of the NLbalancing repository.
-  %%
+%  Calculates a polynomial approximation to the past energy function
+%  for a quadratic drift, polynomial input system. The default usage is
+%
+%  v = approxPastEnergy(A,N,g,C,eta,d,verbose)
+%
+%  where 'verbose' is an optional argument. If the system has a constant
+%  input vector field Bu, the matrix B may be passes in place of the cell
+%  array 'g'. The cell array 'g' should be g{1} = B = G_0, g{2} = G1, g{3} = G2 ...
+%
+%  Computes a degree d polynomial approximation to the past energy function
+%
+%          E^-(x) = 1/2 ( v{2}'*kron(x,x) + ... + v{d}'*kron(.. x) )
+%
+%  for the polynomial system
+%
+%    \dot{x} = Ax + Bu + N*kron(x,x) + G1*kron(x,u) + G2*kron(x,x,u) + ...
+%          y = Cx
+%
+%  where eta = 1-gamma^(-2), gamma is the parameter in the algebraic Riccati
+%  equation
+%
+%    A'*V2 + V2*A + V2*B*B'*V2 - eta*C'*C = 0.
+%
+%  and in the subsequent linear systems arising from the Past H-infinity
+%  Hamilton-Jacobi-Bellman Partial Differential Equation.
+%
+%  Note that v{2} = vec(V2) = V2(:).  Details are in Section III.C of reference [1].
+%
+%  Requires the following functions from the KroneckerTools repository
+%      KroneckerSumSolver
+%      kronMonomialSymmetrize
+%      LyapProduct
+%
+%  Authors: Jeff Borggaard, Virginia Tech
+%           Nick Corbin, UCSD
+%
+%  License: MIT
+%
+%  Reference: [1] Nonlinear balanced truncation: Part 1--Computing energy
+%             functions, by Kramer, Gugercin, and Borggaard, arXiv:2209.07645.
+%             [2] Nonlinear balanced truncation for quadratic bilinear
+%             systems, by Nick Corbin ... (in progress).
+%
+%             See Algorithm 1 in [1].
+%
+%  Part of the NLbalancing repository.
+%%
 
-  if (nargin < 7)
-      verbose = false;
+if (nargin < 7)
+  verbose = false;
+end
+
+% Create pointer/shortcuts for dynamical system polynomial coefficients
+if ismatrix(g)
+  % Will reduce to Jeff's original code
+  B = g;
+  l = 0;
+  g = {B};
+else
+  % QB or polynomial input balancing
+  B = g{1};
+  l = length(g) - 1;
+end
+
+n = size(A, 1); % A should be n-by-n
+m = size(B, 2); % B should be n-by-m
+p = size(C, 1); % C should be p-by-n
+
+% Create a vec function for readability
+vec = @(X) X(:);
+
+%% k=2 case
+R = eye(m);
+
+if (eta ~= 0)
+  %  We multiply the ARE by -1 to put it into the standard form in icare,
+  %  and know (-A,-B) is a controllable pair if (A,B) is.
+  [V2] = icare(-A, -B, eta * (C.' * C), R);
+
+  if (isempty(V2) && verbose)
+    warning('approxPastEnergy: icare couldn''t find stabilizing solution')
   end
 
-  % Create pointer/shortcuts for dynamical system polynomial coefficients
-  if ismatrix(g)
-      % Will reduce to Jeff's original code
-      B = g;
-      l = 0;
-      g = {B};
-  else
-      % QB or polynomial input balancing
-      B = g{1};
-      l = length(g) - 1;
-  end
+  if (isempty(V2))
 
-  n = size(A, 1); % A should be n-by-n
-  m = size(B, 2); % B should be n-by-m
-  p = size(C, 1); % C should be p-by-n
+    if (verbose)
+      warning('approxPastEnergy: using matrix inverse')
+    end
 
-  % Create a vec function for readability
-  vec = @(X) X(:);
+    [Yinf] = icare(A.', C.', B * B.', eye(p) / eta);
 
-  %% k=2 case
-  R = eye(m);
-
-  if (eta ~= 0)
-      %  We multiply the ARE by -1 to put it into the standard form in icare,
-      %  and know (-A,-B) is a controllable pair if (A,B) is.
-      [V2] = icare(-A, -B, eta * (C.' * C), R);
-
-      if (isempty(V2) && verbose)
-          warning('approxPastEnergy: icare couldn''t find stabilizing solution')
-      end
-
-      if (isempty(V2))
-
-          if (verbose)
-              warning('approxPastEnergy: using matrix inverse')
-          end
-
-          [Yinf] = icare(A.', C.', B * B.', eye(p) / eta);
-
-          if (isempty(Yinf))
-              V2 = [];
-          else
-              V2 = inv(Yinf); % yikes!!!
-          end
-
-      end
-
-      if (isempty(V2))
-          if (verbose), fprintf("trying the anti-solution\n"), end
-          [V2] = icare(-A, B, eta * (C.' * C), R, 'anti');
-      end
-
-      if (isempty(V2))
-
-          if (verbose)
-              warning('approxPastEnergy: icare couldn''t find stabilizing solution')
-              fprintf('approxPastEnergy: using the hamiltonian\n')
-          end
-
-          [~, V2, ~] = hamiltonian(-A, B, eta * (C.' * C), R, true);
-          V2 = real(V2);
-      end
-
-      if (isempty(V2))
-          error('Could not find a solution to the ARE, adjust the eta parameter')
-      end
-
-  else % eta==0
-      %  This case is described in Section II.B of the paper and requires a
-      %  matrix inverse to calculate E_c.
-      [V2] = lyap(A, (B * B.'));
-      V2 = inv(V2); % yikes!!!!!!!!
-
-      %  To do: look at approximating this by [V2] = icare(-A,-B,eta*(C.'*C),R)
-      %  with a small value of eta (and perhaps other choices for C.'*C)
+    if (isempty(Yinf))
+      V2 = [];
+    else
+      V2 = inv(Yinf); % yikes!!!
+    end
 
   end
 
-  %  Reshape the resulting quadratic coefficients
-  v{2} = vec(V2);
-
-  %% k=3 case
-  if (d > 2)
-      NaVb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*V_b, etc for all the a,b we need
-      NaVb{1, 2} = B.' * V2; % Recall g{1} = B
-      % set up the generalized Lyapunov solver
-      [Acell{1:d}] = deal(A.' + V2 * (B * B.'));
-
-      b = -LyapProduct(N.', v{2}, 2);
-
-      if l > 0 % New for QB/polynomial input
-          Im = speye(m);
-          NaVb{2, 2} = g{2}.' * V2;
-          b = b - 2 * kron(speye(n ^ 3), vec(Im).') * vec(kron(NaVb{2, 2}, NaVb{1, 2}));
-      end
-
-      [v{3}] = KroneckerSumSolver(Acell(1:3), b, 3);
-      [v{3}] = kronMonomialSymmetrize(v{3}, n, 3);
-
-      %% k>3 case (up to d)
-      for k = 4:d
-          NaVb{1, k - 1} = B.' * reshape(v{k - 1}, n, n ^ (k - 2));
-
-          b = -LyapProduct(N.', v{k - 1}, k - 1);
-
-          for i = 3:(k + 1) / 2
-              j = k + 2 - i;
-              tmp = NaVb{1, i}.' * NaVb{1, j};
-              b = b - 0.25 * i * j * (vec(tmp) + vec(tmp.'));
-          end
-
-          if ~mod(k, 2) % k is even
-              i = (k + 2) / 2;
-              j = i;
-              tmp = NaVb{1, i}.' * NaVb{1, j};
-              b = b - 0.25 * i * j * vec(tmp);
-          end
-
-          % Now add the higher order polynomial terms by iterating through the sums
-          [g{l + 2:2 * l + 1}] = deal(0); % Need an extra space in g because of NaVb indexing
-
-          for o = 1:2 * l
-              NaVb{o + 1, k - 1} = g{o + 1}.' * reshape(v{k - 1}, n, n ^ (k - 2));
-
-              for p = max(0, o - l):min(o, l)
-
-                  for i = 2:k - o
-                      q = o - p;
-                      j = k - o - i + 2;
-                      tmp = kron(speye(n ^ p), vec(Im).') ...
-                          * kron(vec(NaVb{q + 1, j}).', kron(NaVb{p + 1, i}, Im)) ...
-                          * kron(speye(n ^ (j - 1)), kron(perfectShuffle(n ^ (i - 1), n ^ q * m), Im)) ...
-                          * kron(speye(n ^ (k - p)), vec(Im));
-                      b = b - 0.25 * i * j * vec(tmp);
-                  end
-
-              end
-
-          end
-
-          [v{k}] = KroneckerSumSolver(Acell(1:k), b, k);
-          [v{k}] = kronMonomialSymmetrize(v{k}, n, k);
-      end
-
+  if (isempty(V2))
+    if (verbose), fprintf("trying the anti-solution\n"), end
+    [V2] = icare(-A, B, eta * (C.' * C), R, 'anti');
   end
+
+  if (isempty(V2))
+
+    if (verbose)
+      warning('approxPastEnergy: icare couldn''t find stabilizing solution')
+      fprintf('approxPastEnergy: using the hamiltonian\n')
+    end
+
+    [~, V2, ~] = hamiltonian(-A, B, eta * (C.' * C), R, true);
+    V2 = real(V2);
+  end
+
+  if (isempty(V2))
+    error('Could not find a solution to the ARE, adjust the eta parameter')
+  end
+
+else % eta==0
+  %  This case is described in Section II.B of the paper and requires a
+  %  matrix inverse to calculate E_c.
+  [V2] = lyap(A, (B * B.'));
+  V2 = inv(V2); % yikes!!!!!!!!
+
+  %  To do: look at approximating this by [V2] = icare(-A,-B,eta*(C.'*C),R)
+  %  with a small value of eta (and perhaps other choices for C.'*C)
+
+end
+
+%  Reshape the resulting quadratic coefficients
+v{2} = vec(V2);
+
+%% k=3 case
+if (d > 2)
+  GaVb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*V_b, etc for all the a,b we need
+  GaVb{1, 2} = B.' * V2; % Recall g{1} = B
+  % set up the generalized Lyapunov solver
+  [Acell{1:d}] = deal(A.' + V2 * (B * B.'));
+
+  b = -LyapProduct(N.', v{2}, 2);
+
+  if l > 0 % New for QB/polynomial input
+    Im = speye(m);
+    GaVb{2, 2} = g{2}.' * V2;
+    b = b - 2 * kron(speye(n ^ 3), vec(Im).') * vec(kron(GaVb{2, 2}, GaVb{1, 2}));
+  end
+
+  [v{3}] = KroneckerSumSolver(Acell(1:3), b, 3);
+  [v{3}] = kronMonomialSymmetrize(v{3}, n, 3);
+
+  %% k>3 case (up to d)
+  for k = 4:d
+    GaVb{1, k - 1} = B.' * reshape(v{k - 1}, n, n ^ (k - 2));
+
+    b = -LyapProduct(N.', v{k - 1}, k - 1);
+
+    for i = 3:(k + 1) / 2
+      j = k + 2 - i;
+      tmp = GaVb{1, i}.' * GaVb{1, j};
+      b = b - 0.25 * i * j * (vec(tmp) + vec(tmp.'));
+    end
+
+    if ~mod(k, 2) % k is even
+      i = (k + 2) / 2;
+      j = i;
+      tmp = GaVb{1, i}.' * GaVb{1, j};
+      b = b - 0.25 * i * j * vec(tmp);
+    end
+
+    % Now add the higher order polynomial terms by iterating through the sums
+    [g{l + 2:2 * l + 1}] = deal(0); % Need an extra space in g because of GaVb indexing
+
+    for o = 1:2 * l
+      GaVb{o + 1, k - 1} = g{o + 1}.' * reshape(v{k - 1}, n, n ^ (k - 2));
+
+      for p = max(0, o - l):min(o, l)
+
+        for i = 2:k - o
+          q = o - p;
+          j = k - o - i + 2;
+          tmp = kron(speye(n ^ p), vec(Im).') ...
+            * kron(vec(GaVb{q + 1, j}).', kron(GaVb{p + 1, i}, Im)) ...
+            * kron(speye(n ^ (j - 1)), kron(perfectShuffle(n ^ (i - 1), n ^ q * m), Im)) ...
+            * kron(speye(n ^ (k - p)), vec(Im));
+          b = b - 0.25 * i * j * vec(tmp);
+        end
+
+      end
+
+    end
+
+    [v{k}] = KroneckerSumSolver(Acell(1:k), b, k);
+    [v{k}] = kronMonomialSymmetrize(v{k}, n, k);
+  end
+
+end
 
 end

--- a/approxPastEnergy.m
+++ b/approxPastEnergy.m
@@ -52,15 +52,15 @@ if (nargin < 7)
 end
 
 % Create pointer/shortcuts for dynamical system polynomial coefficients
-if ismatrix(g)
+if iscell(g)
+  % QB or polynomial input balancing
+  B = g{1};
+  l = length(g) - 1;
+else
   % Will reduce to Jeff's original code
   B = g;
   l = 0;
   g = {B};
-else
-  % QB or polynomial input balancing
-  B = g{1};
-  l = length(g) - 1;
 end
 
 n = size(A, 1); % A should be n-by-n

--- a/approxPastEnergy.m
+++ b/approxPastEnergy.m
@@ -134,7 +134,7 @@ v{2} = vec(V2);
 
 %% k=3 case
 if (d > 2)
-  GaVb = cell(2 * l + 1, d - 1); % Pre-compute N_a.'*V_b, etc for all the a,b we need
+  GaVb = cell(2 * l + 1, d - 1); % Pre-compute G_a.'*V_b, etc for all the a,b we need
   GaVb{1, 2} = B.' * V2; % Recall g{1} = B
   % set up the generalized Lyapunov solver
   [Acell{1:d}] = deal(A.' + V2 * (B * B.'));


### PR DESCRIPTION
The functions approxPastEnergy.m and approxFutureEnergy.m are generalized to handle systems with the state equation
$$\dot{x} = Ax + Bu + N(x \otimes x) + G_1(x \otimes u) + G_2(x \otimes x \otimes u) + \dots$$

The new functions are backwards compatible in the sense that if you only pass a $B$ matrix, the new portions of the code are skipped. For the new functionality, one would pass a cell array $g$ instead of $B$, with the entries `g{1} = B, g{2} = G_1, ...`. 

The main changes in the code are therefore the extra terms containing $G_1, G_2, \dots$ which need to be added to the RHS of the linear systems to solve for the energy function coefficients. I can provide my writeup with the proofs if requested. These extra terms are implemented in lines 120-123 and 148-168 in approxFutureEnergy.m. 

There are a few other minor code updates as well for speed/efficiency, such as using `[Acell{1:d}] = deal(A.' - eta * W2 * (B * B.'));` to create the Acell variable instead of using for loop (better for memory allocation). 

Apologies that there appear to be so many changes that it seems like the entire functions were re-written; most of the changes Github is picking up are white-space/formatting changes. You should be able to disable whitespaces when doing the code review, but it still thinks more was changed than I actually changed, so I added comments specifically where I made major changes. 

